### PR TITLE
Alternate sending jobs between schedulers

### DIFF
--- a/src/phoenix/frontend/prototype/main.go
+++ b/src/phoenix/frontend/prototype/main.go
@@ -34,8 +34,8 @@ func main() {
 		schedulerClientMap[schedulerAddr] = newSched
 	}
 
-	numTasks := 20
-	numJobs := 10
+	numTasks := 1
+	numJobs := 2
 	done := make(chan bool)
 
 	runJob := func(jobN int, done chan bool, sched phoenix.TaskSchedulerInterface) {

--- a/src/phoenix/monitor/monitor.go
+++ b/src/phoenix/monitor/monitor.go
@@ -190,11 +190,8 @@ func (nm *NodeMonitor) attemptLaunchTask() {
 
 	//check if taskR has a reservation for a task which was not cancelled
 	if taskR, ok := _taskR.(types.TaskReservation); ok {
-		fmt.Printf("[Monitor: attemptLaunchTask]: attempting %s\n", taskR.JobID)
-
 		_, cancelled := nm.cancelled[taskR.JobID]
 		if !cancelled && taskR.IsNotEmpty() {
-			fmt.Printf("[Monitor: attemptLaunchTask]: is not cancelled or empty: %s\n", taskR.JobID)
 			if taskR.IsNotEmpty() {
 				fmt.Printf("[Monitor: attemptLaunchTask]: launching %s\n", taskR.JobID)
 				// TODO: Parallelize with goroutines
@@ -240,8 +237,8 @@ func (nm *NodeMonitor) taskLauncher() {
 			nm.launchCond.Wait()
 		}
 
-		fmt.Println("[Monitor: TaskLauncher] About to attempt launch task, active tasks: ", nm.activeTasks)
-		fmt.Println("[Monitor: TaskLauncher] queueSize: ", nm.queue.Len())
+		// fmt.Println("[Monitor: TaskLauncher] About to attempt launch task, active tasks: ", nm.activeTasks)
+		fmt.Println("[Monitor: TaskLauncher] queueSize before attemptLaunchTask: ", nm.queue.Len())
 		nm.attemptLaunchTask()
 
 		nm.launchCond.L.Unlock()

--- a/src/phoenix/scheduler/task_scheduler.go
+++ b/src/phoenix/scheduler/task_scheduler.go
@@ -185,12 +185,12 @@ func (ts *TaskScheduler) TaskComplete(taskId string, completeResult *bool) error
 		ts.jobStatusLock.Unlock()
 
 		// TODO: Notify the corresponding frontend that the task is finished
-		fmt.Println("--------------------Finished job", jobId)
-		fmt.Println("jobStatus", ts.jobStatus)
-		fmt.Println("taskToJob", ts.taskToJob)
-		fmt.Println("jobLeftTask", ts.jobLeftTask)
-		fmt.Println("jobMap", ts.jobMap)
-		fmt.Println("-------------------", jobId)
+		// fmt.Println("--------------------Finished job", jobId)
+		// fmt.Println("jobStatus", ts.jobStatus)
+		// fmt.Println("taskToJob", ts.taskToJob)
+		// fmt.Println("jobLeftTask", ts.jobLeftTask)
+		// fmt.Println("jobMap", ts.jobMap)
+		// fmt.Println("-------------------", jobId)
 
 	}
 

--- a/src/phoenix/scheduler/task_scheduler.go
+++ b/src/phoenix/scheduler/task_scheduler.go
@@ -72,7 +72,7 @@ var _ phoenix.TaskSchedulerInterface = new(TaskScheduler)
 
 func (ts *TaskScheduler) SubmitJob(job types.Job, submitResult *bool) error {
 
-	fmt.Printf("[Scheduler: SubmitJob]: Scheduling Job %s with %d\n", job.Id, len(job.Tasks))
+	fmt.Printf("[TaskScheduler %s: SubmitJob]: Scheduling Job %s with %d\n", ts.Addr, job.Id, len(job.Tasks))
 
 	enqueueCount := len(job.Tasks) * DefaultSampleRatio
 	ts.jobMapLock.Lock()
@@ -165,7 +165,7 @@ func (ts *TaskScheduler) TaskComplete(taskId string, completeResult *bool) error
 
 	// Clean things up when the job is finished
 	if leftJob == 0 {
-		fmt.Printf("[Scheduler: TaskComplete]: Job %s finished\n", jobId)
+		fmt.Printf("[TaskScheduler %s: TaskComplete]: Job %s finished\n", ts.Addr, jobId)
 		// Only nested lock here. Other place don't have nested lock to avoid deadlock
 		ts.jobStatusLock.Lock()
 		ts.jobMapLock.Lock()
@@ -213,11 +213,12 @@ func (ts *TaskScheduler) enqueueJob(enqueueCount int, jobId string) error {
 
 		targetWorkerId := probeNodesList[targetIndex%len(probeNodesList)]
 		if e := ts.MonitorClientPool[targetWorkerId].EnqueueReservation(taskR, &queuePos); e != nil {
-			fmt.Printf("[TaskScheduler: enqueueJob]: Failed to enqueue reservation on %d\n", targetWorkerId)
+			fmt.Printf("[TaskScheduler %s: enqueueJob]: Failed to enqueue reservation on %d\n",
+				ts.Addr, targetWorkerId)
 		}
 
-		fmt.Printf("[TaskScheduler: enqueueJob]: Enqueuing reservation on monitor %d for job reservation %s\n",
-			targetWorkerId, taskR.JobID)
+		fmt.Printf("[TaskScheduler %s: enqueueJob]: Enqueuing reservation on monitor %d for job reservation %s\n",
+			ts.Addr, targetWorkerId, taskR.JobID)
 
 		// if e != nil {
 		// 	// Remove the inactive back


### PR DESCRIPTION
Scheduler logs for 2 1-task jobs distributed amongst 2 decentralized schedulers in a 2s-4m-4e setup. Front-end ran twice in a row.
```
2020/05/25 18:49:56 scheduler serving on localhost:33494
2020/05/25 18:49:56 scheduler serving on localhost:33493
[TaskScheduler localhost:33493: SubmitJob]: Scheduling Job job0 with 1
[TaskScheduler localhost:33494: SubmitJob]: Scheduling Job job1 with 1
[TaskScheduler localhost:33493: enqueueJob]: Enqueuing reservation on monitor 3 for job reservation job0
[TaskScheduler localhost:33494: enqueueJob]: Enqueuing reservation on monitor 1 for job reservation job1

[TaskScheduler localhost:33494: enqueueJob]: Enqueuing reservation on monitor 0 for job reservation job1
[TaskScheduler localhost:33493: enqueueJob]: Enqueuing reservation on monitor 0 for job reservation job0

[TaskScheduler localhost:33494: TaskComplete]: Job job1 finished
[TaskScheduler localhost:33493: TaskComplete]: Job job0 finished
[TaskScheduler localhost:33493: SubmitJob]: Scheduling Job job0 with 1
[TaskScheduler localhost:33494: SubmitJob]: Scheduling Job job1 with 1
[TaskScheduler localhost:33493: enqueueJob]: Enqueuing reservation on monitor 0 for job reservation job0

[TaskScheduler localhost:33494: enqueueJob]: Enqueuing reservation on monitor 0 for job reservation job1
[TaskScheduler localhost:33493: enqueueJob]: Enqueuing reservation on monitor 1 for job reservation job0

[TaskScheduler localhost:33494: enqueueJob]: Enqueuing reservation on monitor 1 for job reservation job1
[TaskScheduler localhost:33494: TaskComplete]: Job job1 finished
[TaskScheduler localhost:33493: TaskComplete]: Job job0 finished

```