### PR TITLE
worker-god and resilience to worker failures

### DIFF
--- a/src/phoenix/Makefile
+++ b/src/phoenix/Makefile
@@ -1,3 +1,6 @@
 
 all:
 	go install ./...
+
+clean:
+	rm logs/*.log

--- a/src/phoenix/config/config.go
+++ b/src/phoenix/config/config.go
@@ -33,12 +33,19 @@ type TaskSchedulerConfig struct {
 	Ready         chan bool
 }
 
+type WorkerGodConfig struct {
+	Addr          string
+	WorkerGod 	  phoenix.WorkerGod
+	Ready         chan bool
+}
+
 type PhoenixConfig struct {
 	NumSlots   int
 	Frontends  []string
 	Schedulers []string
 	Monitors   []string
 	Executors  []string
+	WorkerGods []string
 }
 
 func (pc *PhoenixConfig) NewFrontendConfig(i int, fe phoenix.FrontendInterface) *FrontendConfig {
@@ -69,6 +76,14 @@ func (pc *PhoenixConfig) NewExecutorConfig(i int, ec phoenix.ExecutorInterface) 
 	return &ExecutorConfig{
 		Addr:     pc.Executors[i],
 		Executor: ec,
+		Ready:    make(chan bool, 1),
+	}
+}
+
+func (pc *PhoenixConfig) NewWorkerGodConfig(i int, ec phoenix.WorkerGod) *WorkerGodConfig {
+	return &WorkerGodConfig{
+		Addr:     pc.WorkerGods[i],
+		WorkerGod: ec,
 		Ready:    make(chan bool, 1),
 	}
 }

--- a/src/phoenix/config/config.go
+++ b/src/phoenix/config/config.go
@@ -80,10 +80,10 @@ func (pc *PhoenixConfig) NewExecutorConfig(i int, ec phoenix.ExecutorInterface) 
 	}
 }
 
-func (pc *PhoenixConfig) NewWorkerGodConfig(i int, ec phoenix.WorkerGod) *WorkerGodConfig {
+func (pc *PhoenixConfig) NewWorkerGodConfig(i int, ww phoenix.WorkerGod) *WorkerGodConfig {
 	return &WorkerGodConfig{
 		Addr:     pc.WorkerGods[i],
-		WorkerGod: ec,
+		WorkerGod: ww,
 		Ready:    make(chan bool, 1),
 	}
 }

--- a/src/phoenix/frontend/manual-1/main.go
+++ b/src/phoenix/frontend/manual-1/main.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"math/rand"
+	"phoenix"
+	"phoenix/config"
+	"phoenix/frontend"
+	"phoenix/scheduler"
+	"phoenix/types"
+	"strconv"
+	"time"
+)
+
+var frc = flag.String("conf", config.DefaultConfigPath, "config file")
+
+func noError(e error) {
+	if e != nil {
+		log.Fatal(e)
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	rc, e := config.LoadConfig(*frc)
+	noError(e)
+
+	fmt.Println("Instantiated Monitors and Executors")
+
+	schedulerClients := make([]phoenix.TaskSchedulerInterface, 0)
+	for _, schedulerAddr := range rc.Schedulers {
+		newSched := scheduler.GetNewTaskSchedulerClient(schedulerAddr)
+		schedulerClients = append(schedulerClients, newSched)
+	}
+
+	// Only one frontend
+	feAddr := rc.Frontends[0]
+	jobDoneChan := make(chan string)
+	fe, sendJobsChan := frontend.NewFrontend(feAddr, schedulerClients, jobDoneChan)
+
+	feConfig := rc.NewFrontendConfig(0, fe)
+
+	// run Frontend server
+	go frontend.ServeFrontend(feConfig)
+	<- feConfig.Ready
+
+	// TODO: randomize number of jobs or tasks
+	numTasks := 10
+	numJobs := 10
+
+	jobList := make([]*types.Job, 20)
+	var sumOfTaskTimes float32 = 0
+
+	// populate jobList
+	for i := 0; i < numJobs; i++ {
+		jobid := "job" + strconv.Itoa(i)
+		tasks := make([]types.Task, 0)
+		for j := 0; j < numTasks; j++ {
+			taskid := jobid + "-task" + strconv.Itoa(j)
+
+			taskTime := rand.Float32()
+			sumOfTaskTimes += taskTime
+			task := types.Task{JobId: jobid, Id: taskid, T: taskTime}
+
+			tasks = append(tasks, task)
+		}
+
+		jobList[i] = &types.Job{
+			Id: jobid,
+			Tasks: tasks,
+
+			// TODO: Currently we only test with one frontend
+			OwnerAddr: feAddr,
+		}
+	}
+
+	allJobsDoneSignal := make(chan bool)
+
+	// run jobs
+	startTime := time.Now()
+	for i := 0; i < numJobs; i++ {
+		// TODO: does using go routines here improve performance?
+		sendJobsChan <- jobList[i]
+	}
+
+	// wait for all jobs to end
+	go func() {
+		for i := 0; i < numJobs; i++ {
+			fmt.Println("finished job: ", <-jobDoneChan)
+		}
+		allJobsDoneSignal <- true
+	}()
+
+	<- allJobsDoneSignal
+
+	timeTaken := float32(time.Since(startTime).Seconds())
+
+	slotCount := len(rc.Executors) * rc.NumSlots
+	theoreticalLowerBound := sumOfTaskTimes / float32(slotCount)
+
+	overhead := 100 * (timeTaken/theoreticalLowerBound - 1)
+
+	fmt.Printf("Complete time taken for test in seconds: %f\n", timeTaken)
+	fmt.Printf("Total time of jobs in seconds: %f\n", sumOfTaskTimes)
+	fmt.Printf("We are within %f percent of the theoretical lower bound\n", overhead)
+
+	writeToFile(rc, numJobs, numTasks, timeTaken, overhead)
+}
+
+func writeToFile(rc *config.PhoenixConfig, jobCount, taskCount int, timeTaken, overhead float32) error {
+	logName := "logs/" + strconv.Itoa(len(rc.Schedulers)) + "_sched:" + strconv.Itoa(len(rc.Monitors)) + "_mtor:" +
+		strconv.Itoa(rc.NumSlots) + "_slots" + strconv.Itoa(taskCount) + "_tasks.log"
+
+	fout, e := rc.Write(logName)
+
+	if e != nil {
+		return e
+	}
+
+	fout.WriteString(fmt.Sprintf("\njobCount: %d, taskCount: %d, timeTaken: %f, overhead percent: %f\n",
+		jobCount, taskCount, timeTaken, overhead))
+	fout.Close()
+	return nil
+}

--- a/src/phoenix/frontend/manual-1/main.go
+++ b/src/phoenix/frontend/manual-1/main.go
@@ -79,6 +79,9 @@ func main() {
 
 	allJobsDoneSignal := make(chan bool)
 
+	// time taken by jobs
+	var timeTaken float32
+
 	// run jobs
 	startTime := time.Now()
 	for i := 0; i < numJobs; i++ {
@@ -91,12 +94,15 @@ func main() {
 		for i := 0; i < numJobs; i++ {
 			fmt.Println("finished job: ", <-jobDoneChan)
 		}
+
+		// set time taken
+		timeTaken = float32(time.Since(startTime).Seconds())
 		allJobsDoneSignal <- true
 	}()
 
-	<- allJobsDoneSignal
+	// We can use worker-god to start or kill more jobs here
 
-	timeTaken := float32(time.Since(startTime).Seconds())
+	<- allJobsDoneSignal
 
 	slotCount := len(rc.Executors) * rc.NumSlots
 	theoreticalLowerBound := sumOfTaskTimes / float32(slotCount)

--- a/src/phoenix/frontend/manual-2/main.go
+++ b/src/phoenix/frontend/manual-2/main.go
@@ -65,7 +65,7 @@ func main() {
 
 	// TODO: randomize number of jobs or tasks
 	numTasks := 10
-	numJobs := 10
+	numJobs := 20
 
 	jobList := make([]*types.Job, 20)
 	var sumOfTaskTimes float32 = 0
@@ -120,6 +120,7 @@ func main() {
 			panic(e)
 		}
 		fmt.Println("Killed workerId:", i)
+		time.Sleep(1 * time.Second)
 
 		workersKilled = append(workersKilled, i)
 	}
@@ -128,13 +129,14 @@ func main() {
 	time.Sleep(ZK_DETECT_TIME)
 
 	// bring workers back
-	//for _, id := range workersKilled {
-	//	var ret bool
-	//	if e := workerGodClient.Start(id, &ret); e != nil || !ret {
-	//		panic(e)
-	//	}
-	//	fmt.Println("Brought back workerId:", id)
-	//}
+	for _, id := range workersKilled {
+		var ret bool
+		if e := workerGodClient.Start(id, &ret); e != nil || !ret {
+			panic(e)
+		}
+		fmt.Println("Brought back workerId:", id)
+		time.Sleep(1 * time.Second)
+	}
 
 	// sleep for Kills to take affect
 	time.Sleep(ZK_DETECT_TIME)

--- a/src/phoenix/frontend/manual-2/main.go
+++ b/src/phoenix/frontend/manual-2/main.go
@@ -95,6 +95,9 @@ func main() {
 
 	allJobsDoneSignal := make(chan bool)
 
+	// time taken by jobs
+	var timeTaken float32
+
 	// run jobs
 	startTime := time.Now()
 	for i := 0; i < numJobs; i++ {
@@ -107,6 +110,7 @@ func main() {
 		for i := 0; i < numJobs; i++ {
 			fmt.Println("finished job: ", <-jobDoneChan)
 		}
+		timeTaken = float32(time.Since(startTime).Seconds())
 		allJobsDoneSignal <- true
 	}()
 
@@ -144,7 +148,6 @@ func main() {
 	fmt.Println("Done Sleeping")
 	<- allJobsDoneSignal
 
-	timeTaken := float32(time.Since(startTime).Seconds())
 
 	slotCount := len(rc.Executors) * rc.NumSlots
 	theoreticalLowerBound := sumOfTaskTimes / float32(slotCount)

--- a/src/phoenix/init/init-config/main.go
+++ b/src/phoenix/init/init-config/main.go
@@ -29,8 +29,10 @@ func main() {
 	phoenixConfig.Monitors = make([]string, *nMonitors)
 	phoenixConfig.NumSlots = *nSlots
 
-	// same number of executors as monitors
+	// same number of and workerGods executors as monitors
 	phoenixConfig.Executors = make([]string, *nMonitors)
+	phoenixConfig.WorkerGods = make([]string, *nMonitors)
+
 
 	ipAddrs := strings.Split(*ips, ",")
 	if nMachine := len(ipAddrs); nMachine > 0 {
@@ -43,9 +45,14 @@ func main() {
 		for i := 0; i < *nMonitors; i++ {
 			host := fmt.Sprintf("%s", ipAddrs[i%nMachine])
 			phoenixConfig.Monitors[i] = fmt.Sprintf("%s:%d", host, p)
+			p++
 
 			// run Executors on same machine as monitors
-			phoenixConfig.Executors[i] = fmt.Sprintf("%s:%d", host, p+1000)
+			phoenixConfig.Executors[i] = fmt.Sprintf("%s:%d", host, p)
+			p++
+
+			// run WorkerGod on same machine as monitors
+			phoenixConfig.WorkerGods[i] = fmt.Sprintf("%s:%d", host, p)
 			p++
 		}
 

--- a/src/phoenix/init/init-executor/main.go
+++ b/src/phoenix/init/init-executor/main.go
@@ -11,6 +11,9 @@ import (
 
 var frc = flag.String("conf", config.DefaultConfigPath, "config file")
 
+// if workerId is -1 then run all workers
+var workerId = flag.Int("workerId", -1, "which workerId to run")
+
 func noError(e error) {
 	if e != nil {
 		log.Fatal(e)
@@ -40,14 +43,13 @@ func main() {
 		noError(executor.ServeExecutor(eConfig))
 	}
 
-	n := 0
-
-	for i, _ := range rc.Monitors {
-		go run(i)
-		n++
+	if *workerId == -1 {
+		for i, _ := range rc.Monitors {
+			go run(i)
+		}
+	} else {
+		run(*workerId)
 	}
 
-	if n > 0 {
-		select {}
-	}
+	select {}
 }

--- a/src/phoenix/init/init-monitor/main.go
+++ b/src/phoenix/init/init-monitor/main.go
@@ -13,6 +13,9 @@ import (
 
 var frc = flag.String("conf", config.DefaultConfigPath, "config file")
 
+// if -1, run all workers
+var workerId = flag.Int("workerId", -1, "which workerId to run")
+
 func noError(e error) {
 	if e != nil {
 		log.Fatal(e)
@@ -49,14 +52,15 @@ func main() {
 		noError(monitor.ServeMonitor(mConfig))
 	}
 
-	n := 0
-
-	for i, _ := range rc.Monitors {
-		go run(i)
-		n++
+	// run all monitors
+	if *workerId == -1 {
+		for i, _ := range rc.Monitors {
+			go run(i)
+		}
+	} else {
+		run(*workerId)
 	}
 
-	if n > 0 {
-		select {}
-	}
+	select {}
+
 }

--- a/src/phoenix/init/init-worker-god/main.go
+++ b/src/phoenix/init/init-worker-god/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"phoenix/config"
+	workerGod "phoenix/worker-god"
+)
+
+var frc = flag.String("conf", config.DefaultConfigPath, "config file")
+
+// if workerId is 0, run the first god
+var workerId = flag.Int("workerId", 0, "which workerId to run")
+
+func noError(e error) {
+	if e != nil {
+		log.Fatal(e)
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	rc, e := config.LoadConfig(*frc)
+	noError(e)
+
+	godRc := rc.NewWorkerGodConfig(*workerId, workerGod.NewWorkerGod(rc))
+
+	noError(workerGod.ServeWorkerGod(godRc))
+}

--- a/src/phoenix/interfaces.go
+++ b/src/phoenix/interfaces.go
@@ -4,6 +4,11 @@ import (
 	"phoenix/types"
 )
 
+type WorkerGod interface {
+	Kill(workerId int, ret *bool) error
+	Start(workerId int, ret *bool) error
+}
+
 type FrontendInterface interface {
 
 	JobComplete(jobId string, ret *bool) error
@@ -26,7 +31,7 @@ type MonitorInterface interface {
 
 type TaskSchedulerInterface interface {
 	SubmitJob(job types.Job, submitResult *bool) error
-	GetTask(jobId string, taskRequest *types.TaskRequest) error
+	GetTask(taskRequest types.TaskRequest, task *types.Task) error
 	TaskComplete(msg types.WorkerTaskCompleteMsg, completeResult *bool) error
 }
 

--- a/src/phoenix/monitor/client.go
+++ b/src/phoenix/monitor/client.go
@@ -7,13 +7,13 @@ import (
 )
 
 type NodeMonitorClient struct {
-	addr string
+	Addr string
 	conn *rpc.Client
 	lock sync.Mutex
 }
 
 func GetNewClient(addr string) *NodeMonitorClient {
-	return &NodeMonitorClient{addr: addr}
+	return &NodeMonitorClient{Addr: addr}
 }
 
 func (nmc *NodeMonitorClient) rpcConn() error {
@@ -25,7 +25,7 @@ func (nmc *NodeMonitorClient) rpcConn() error {
 	}
 
 	var err error
-	nmc.conn, err = rpc.DialHTTP("tcp", nmc.addr)
+	nmc.conn, err = rpc.DialHTTP("tcp", nmc.Addr)
 	if err != nil {
 		nmc.conn = nil
 	}

--- a/src/phoenix/scheduler/task_scheduler_client.go
+++ b/src/phoenix/scheduler/task_scheduler_client.go
@@ -47,13 +47,13 @@ func (tsc *TaskSchedulerClient) SubmitJob(job types.Job, submitResult *bool) err
 	return nil
 }
 
-func (tsc *TaskSchedulerClient) GetTask(taskId string, taskRequest *types.TaskRequest) error {
+func (tsc *TaskSchedulerClient) GetTask(taskRequest types.TaskRequest, task *types.Task) error {
 	err := tsc.rpcConn()
 	if err != nil {
 		return err
 	}
 
-	err = tsc.conn.Call("TaskScheduler.GetTask", taskId, taskRequest)
+	err = tsc.conn.Call("TaskScheduler.GetTask", taskRequest, task)
 	if err != nil {
 		return err
 	}

--- a/src/phoenix/types/types.go
+++ b/src/phoenix/types/types.go
@@ -11,7 +11,7 @@ type Task struct {
 }
 
 type TaskRequest struct {
-	Task 	 	*Task
+	JobId 	 	string
 	WorkerAddr	string
 }
 

--- a/src/phoenix/worker-god/client.go
+++ b/src/phoenix/worker-god/client.go
@@ -1,0 +1,55 @@
+package worker_god
+
+import (
+	"net/rpc"
+	"phoenix"
+	"sync"
+)
+
+func GetNewClient(addr string) phoenix.WorkerGod {
+	return &WorkerGodClient{addr: addr}
+}
+
+type WorkerGodClient struct {
+	addr string
+	conn *rpc.Client
+	lock sync.Mutex
+}
+
+var _ phoenix.WorkerGod = &WorkerGodClient{}
+
+func (ww *WorkerGodClient) rpcConn() error {
+	ww.lock.Lock()
+	defer ww.lock.Unlock()
+
+	if ww.conn != nil {
+		return nil
+	}
+
+	var err error
+	ww.conn, err = rpc.DialHTTP("tcp", ww.addr)
+	if err != nil {
+		ww.conn = nil
+	}
+	return err
+}
+
+func (ww *WorkerGodClient) Kill(workerId int, submitResult *bool) error {
+
+	err := ww.rpcConn()
+	if err != nil {
+		return err
+	}
+
+	return ww.conn.Call("WorkerWrapper.Kill", workerId, submitResult)
+}
+
+func (ww *WorkerGodClient) Start(workerId int, submitResult *bool) error {
+
+	err := ww.rpcConn()
+	if err != nil {
+		return err
+	}
+
+	return ww.conn.Call("WorkerWrapper.Start", workerId, submitResult)
+}

--- a/src/phoenix/worker-god/server.go
+++ b/src/phoenix/worker-god/server.go
@@ -1,0 +1,29 @@
+package worker_god
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/rpc"
+	"phoenix/config"
+)
+
+func ServeWorkerGod(b *config.WorkerGodConfig) error {
+	server := rpc.NewServer()
+	server.Register(b.WorkerGod)
+
+	listener, err := net.Listen("tcp", b.Addr)
+	if err != nil {
+		if b.Ready != nil { //nil channel blocks
+			b.Ready <- false
+		}
+		return err
+	}
+
+	if b.Ready != nil { //nil channel blocks
+		b.Ready <- true
+	}
+
+	fmt.Println("Launching WorkerGod on ", b.Addr)
+	return http.Serve(listener, server)
+}

--- a/src/phoenix/worker-god/workergod.go
+++ b/src/phoenix/worker-god/workergod.go
@@ -121,9 +121,9 @@ func (ww *WorkerWrapper) Start(workerId int, ret* bool) error {
 
 	// save output to logs
 	go writeToLog(mStdout, "logs/monitor_"+strconv.Itoa(workerId)+"_" +
-		strconv.FormatInt(time.Now().Unix(), 10)+".log")
+		strconv.FormatInt(time.Now().Unix(), 36)+".log")
 	go writeToLog(eStdout, "logs/executor_"+strconv.Itoa(workerId)+"_" +
-		strconv.FormatInt(time.Now().Unix(), 10)+".log")
+		strconv.FormatInt(time.Now().Unix(), 36)+".log")
 
 	*ret = true
 	return nil

--- a/src/phoenix/worker-god/workergod.go
+++ b/src/phoenix/worker-god/workergod.go
@@ -1,0 +1,143 @@
+package worker_god
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/pkg/errors"
+	"io"
+	"os"
+	"os/exec"
+	"phoenix"
+	"phoenix/config"
+	"strconv"
+	"time"
+)
+
+
+type WorkerWrapper struct {
+
+	// map where key is worker index and value is processId for that worker
+	RunningMonitors 	map[int] *exec.Cmd
+	RunningExecutors 	map[int] *exec.Cmd
+
+	// phoenix configuration
+	Config 				*config.PhoenixConfig
+}
+
+func NewWorkerGod(config *config.PhoenixConfig) phoenix.WorkerGod {
+	return &WorkerWrapper{
+		RunningMonitors: make(map[int]*exec.Cmd),
+		RunningExecutors: make(map[int]*exec.Cmd),
+		Config: config,
+	}
+}
+
+func (ww *WorkerWrapper) Kill(workerId int, ret *bool) error {
+
+	fmt.Println("[WorkerWrapper: Kill] workerId:", workerId)
+
+	killError := false
+	errorString := ""
+
+	mCmd, mExists := ww.RunningMonitors[workerId]
+	if mExists {
+		if err := mCmd.Process.Kill(); err != nil {
+			killError = true
+			errorString += fmt.Sprintf("Failed to kill monitor process for worker:%d.\n", workerId)
+		}
+	}
+
+	// if mCmd exists, we hold an invariant that the respective eCmd must as well
+	eCmd, eExists := ww.RunningExecutors[workerId]
+	if eExists {
+		if err := eCmd.Process.Kill(); err != nil {
+			killError = true
+			errorString += fmt.Sprintf("Failed to kill executor process for worker:%d.\n", workerId)
+		}
+	}
+
+	// delete from hashmap if key exists
+	delete(ww.RunningMonitors, workerId)
+	delete(ww.RunningExecutors, workerId)
+
+	if killError {
+		*ret = false
+		return errors.New(errorString)
+	}
+
+	*ret = true
+	return nil
+}
+
+func (ww *WorkerWrapper) Start(workerId int, ret* bool) error {
+
+	fmt.Println("[WorkerWrapper: Start] workerId:", workerId)
+
+	errorString := ""
+	startError := false
+
+	_, mExists := ww.RunningMonitors[workerId]
+	if mExists {
+		startError = true
+		errorString += fmt.Sprintf("Monitor process for worker:%d is already running.\n", workerId)
+	}
+
+	_, eExists := ww.RunningExecutors[workerId]
+	if eExists {
+		startError = true
+		errorString += fmt.Sprintf("Executor process for worker:%d is already running.\n", workerId)
+	}
+
+	if startError {
+		*ret = false
+		return errors.New(errorString)
+	}
+
+	// by this point, we have ascertained that the monitor and executor for workerId do not exist
+	mtor := exec.Command("init-monitor", "-workerId", strconv.Itoa(workerId))
+	etor := exec.Command("init-executor", "-workerId", strconv.Itoa(workerId))
+
+
+	ww.RunningMonitors[workerId] = mtor
+	ww.RunningExecutors[workerId] = etor
+
+	// extract stdout pipes
+	mStdout, _ := mtor.StdoutPipe()
+	eStdout, _ := etor.StdoutPipe()
+
+	// start processes
+	if err := mtor.Start(); err != nil {
+		*ret = false
+		return fmt.Errorf("Error starting monitor process for workerId:%d\n", workerId)
+	}
+
+	if err := etor.Start(); err != nil {
+		// kill mtor command
+		mtor.Process.Kill()
+
+		*ret = false
+		return fmt.Errorf("Error starting executor process for workerId:%d\n", workerId)
+	}
+
+	// save output to logs
+	go writeToLog(mStdout, "logs/monitor_"+strconv.Itoa(workerId)+"_" +
+		strconv.FormatInt(time.Now().Unix(), 10)+".log")
+	go writeToLog(eStdout, "logs/executor_"+strconv.Itoa(workerId)+"_" +
+		strconv.FormatInt(time.Now().Unix(), 10)+".log")
+
+	*ret = true
+	return nil
+}
+
+func writeToLog(out io.ReadCloser, logFileName string) {
+	scanner := bufio.NewScanner(out)
+	scanner.Split(bufio.ScanLines)
+
+	logFile, _ := os.OpenFile(logFileName, os.O_CREATE | os.O_RDWR, 0777)
+	for scanner.Scan() {
+		m := scanner.Text()
+		logFile.WriteString(m + "\n")
+	}
+}
+
+


### PR DESCRIPTION
Introduces Worker-God. A manager that lives on nodes and exposes RPC calls to kill or start workers (corresponding monitor - executor pairs). 

Is able to survive multi-node failures. Current tests can withstand n-1 failures out of n nodes.