### PR TITLE
 Fault Tolerance test

### DIFF
--- a/src/phoenix/frontend/ft-test/main.go
+++ b/src/phoenix/frontend/ft-test/main.go
@@ -16,6 +16,9 @@ import (
 )
 
 var frc = flag.String("conf", config.DefaultConfigPath, "config file")
+var killableWorkers = flag.Int("n", 1, "maximum number of workers to kill")
+var recoverFlag = flag.Bool("r", false, "Recover killed workers?")
+var workloadFlag = flag.String("w", "small", "Size of workload - small, medium, big")
 
 func noError(e error) {
 	if e != nil {
@@ -25,11 +28,25 @@ func noError(e error) {
 
 const ZK_DETECT_TIME = 3 * time.Second
 
+var workloadMap = map[string][]int{
+	"small":  []int{50, 10},
+	"medium": []int{100, 25},
+	"big":    []int{200, 50},
+}
+
 func main() {
 	flag.Parse()
 
 	rc, e := config.LoadConfig(*frc)
 	noError(e)
+
+	workload, ok := workloadMap[*workloadFlag]
+	if !ok {
+		panic("Incorrect workload option")
+	}
+	if *killableWorkers >= len(rc.Monitors) {
+		panic("Can not kill all monitors")
+	}
 
 	// create just one workerGodClient for single-node configuration
 	workerGodClient := workerGod.GetNewClient(rc.WorkerGods[0])
@@ -64,11 +81,13 @@ func main() {
 	<-feConfig.Ready
 
 	// TODO: randomize number of jobs or tasks
-	numTasks := 10
-	numJobs := 20
+	numTasks := workload[1]
+	numJobs := workload[0]
 
-	jobList := make([]*types.Job, 20)
+	jobList := make([]*types.Job, numJobs)
 	var sumOfTaskTimes float64 = 0
+	s1 := rand.NewSource(0)
+	r1 := rand.New(s1)
 
 	// populate jobList
 	for i := 0; i < numJobs; i++ {
@@ -77,7 +96,7 @@ func main() {
 		for j := 0; j < numTasks; j++ {
 			taskid := jobid + "-task" + strconv.Itoa(j)
 
-			taskTime := rand.Float64() / 10
+			taskTime := r1.Float64()
 			sumOfTaskTimes += taskTime
 			task := types.Task{JobId: jobid, Id: taskid, T: taskTime}
 
@@ -116,15 +135,15 @@ func main() {
 
 	time.Sleep(ZK_DETECT_TIME)
 
-	// randomly kill and spawn monitors
+	//randomly kill and spawn monitors
 	workersKilled := make([]int, 0)
-	for i := 0; len(rc.Monitors)-len(workersKilled) > 1; i++ {
+	for i := 0; i < *killableWorkers; i++ {
 		var ret bool
 		if e := workerGodClient.Kill(i, &ret); e != nil || !ret {
 			panic(e)
 		}
 		fmt.Println("Killed workerId:", i)
-		time.Sleep(1 * time.Second)
+		time.Sleep(100 * time.Millisecond)
 
 		workersKilled = append(workersKilled, i)
 	}
@@ -132,18 +151,20 @@ func main() {
 	// sleep for Kills to take affect
 	time.Sleep(ZK_DETECT_TIME)
 
-	// bring workers back
-	for _, id := range workersKilled {
-		var ret bool
-		if e := workerGodClient.Start(id, &ret); e != nil || !ret {
-			panic(e)
+	if *recoverFlag {
+		// bring workers back
+		for _, id := range workersKilled {
+			var ret bool
+			if e := workerGodClient.Start(id, &ret); e != nil || !ret {
+				panic(e)
+			}
+			fmt.Println("Brought back workerId:", id)
+			time.Sleep(1 * time.Second)
 		}
-		fmt.Println("Brought back workerId:", id)
-		time.Sleep(1 * time.Second)
-	}
 
-	// sleep for Kills to take affect
-	time.Sleep(ZK_DETECT_TIME)
+		// sleep for Kills to take affect
+		time.Sleep(ZK_DETECT_TIME)
+	}
 
 	fmt.Println("Done Sleeping")
 	<-allJobsDoneSignal
@@ -153,6 +174,10 @@ func main() {
 
 	overhead := 100 * (timeTaken/theoreticalLowerBound - 1)
 
+	fmt.Printf("\n-----Summary---------\n")
+	fmt.Printf("Workload: %d Jobs %d Tasks\n", workload[0], workload[1])
+	fmt.Printf("Killed %d workers\n", *killableWorkers)
+	fmt.Printf("Recovery: %t\n", *recoverFlag)
 	fmt.Printf("Complete time taken for test in seconds: %f\n", timeTaken)
 	fmt.Printf("Total time of jobs in seconds: %f\n", sumOfTaskTimes)
 	fmt.Printf("We are within %f percent of the theoretical lower bound\n", overhead)

--- a/src/phoenix/frontend/ft-test/main.go
+++ b/src/phoenix/frontend/ft-test/main.go
@@ -19,6 +19,8 @@ var frc = flag.String("conf", config.DefaultConfigPath, "config file")
 var killableWorkers = flag.Int("n", 1, "maximum number of workers to kill")
 var recoverFlag = flag.Bool("r", false, "Recover killed workers?")
 var workloadFlag = flag.String("w", "small", "Size of workload - small, medium, big")
+var seed = flag.Bool("seed", false, "whether to use random task durations")
+var meanDuration = flag.Float64("tasktime", 1.0, "job duration in second")
 
 func noError(e error) {
 	if e != nil {
@@ -93,10 +95,12 @@ func main() {
 	for i := 0; i < numJobs; i++ {
 		jobid := "job" + strconv.Itoa(i)
 		tasks := make([]types.Task, 0)
+		taskTime := *meanDuration
 		for j := 0; j < numTasks; j++ {
+			if *seed {
+				taskTime *= r1.ExpFloat64()
+			}
 			taskid := jobid + "-task" + strconv.Itoa(j)
-
-			taskTime := r1.Float64()
 			sumOfTaskTimes += taskTime
 			task := types.Task{JobId: jobid, Id: taskid, T: taskTime}
 

--- a/src/phoenix/frontend/ft-test/main.go
+++ b/src/phoenix/frontend/ft-test/main.go
@@ -51,12 +51,15 @@ func main() {
 	}
 
 	// create just one workerGodClient for single-node configuration
-	workerGodClient := workerGod.GetNewClient(rc.WorkerGods[0])
+	var workerGodClients []phoenix.WorkerGod
+	for i := 0; i < len(rc.WorkerGods); i++ {
+		workerGodClients[i] = workerGod.GetNewClient(rc.WorkerGods[i])
+	}
 
 	// spawn new monitors and executors
 	for i := range rc.Monitors {
 		var ret bool
-		if e := workerGodClient.Start(i, &ret); e != nil || !ret {
+		if e := workerGodClients[i].Start(i, &ret); e != nil || !ret {
 			panic(e)
 		}
 	}
@@ -141,7 +144,7 @@ func main() {
 	workersKilled := make([]int, 0)
 	for i := 0; i < *killableWorkers; i++ {
 		var ret bool
-		if e := workerGodClient.Kill(i, &ret); e != nil || !ret {
+		if e := workerGodClients[i].Kill(i, &ret); e != nil || !ret {
 			panic(e)
 		}
 		fmt.Println("Killed workerId:", i)
@@ -157,7 +160,7 @@ func main() {
 		// bring workers back
 		for _, id := range workersKilled {
 			var ret bool
-			if e := workerGodClient.Start(id, &ret); e != nil || !ret {
+			if e := workerGodClients[id].Start(id, &ret); e != nil || !ret {
 				panic(e)
 			}
 			fmt.Println("Brought back workerId:", id)

--- a/src/phoenix/frontend/ft-test/main.go
+++ b/src/phoenix/frontend/ft-test/main.go
@@ -19,7 +19,7 @@ var frc = flag.String("conf", config.DefaultConfigPath, "config file")
 var killableWorkers = flag.Int("n", 1, "maximum number of workers to kill")
 var recoverFlag = flag.Bool("r", false, "Recover killed workers?")
 var workloadFlag = flag.String("w", "small", "Size of workload - small, medium, big")
-var seed = flag.Bool("seed", false, "whether to use random task durations")
+var seed = flag.Int64("seed", 0, "seed for random task durations")
 var meanDuration = flag.Float64("tasktime", 1.0, "job duration in second")
 
 func noError(e error) {
@@ -88,7 +88,7 @@ func main() {
 
 	jobList := make([]*types.Job, numJobs)
 	var sumOfTaskTimes float64 = 0
-	s1 := rand.NewSource(0)
+	s1 := rand.NewSource(*seed)
 	r1 := rand.New(s1)
 
 	// populate jobList
@@ -96,10 +96,8 @@ func main() {
 		jobid := "job" + strconv.Itoa(i)
 		tasks := make([]types.Task, 0)
 		taskTime := *meanDuration
+		taskTime *= r1.ExpFloat64()
 		for j := 0; j < numTasks; j++ {
-			if *seed {
-				taskTime *= r1.ExpFloat64()
-			}
 			taskid := jobid + "-task" + strconv.Itoa(j)
 			sumOfTaskTimes += taskTime
 			task := types.Task{JobId: jobid, Id: taskid, T: taskTime}

--- a/src/phoenix/frontend/manual-2/main.go
+++ b/src/phoenix/frontend/manual-2/main.go
@@ -77,7 +77,7 @@ func main() {
 		for j := 0; j < numTasks; j++ {
 			taskid := jobid + "-task" + strconv.Itoa(j)
 
-			taskTime := rand.Float64() / 10
+			taskTime := rand.Float64()
 			sumOfTaskTimes += taskTime
 			task := types.Task{JobId: jobid, Id: taskid, T: taskTime}
 

--- a/src/phoenix/monitor/monitor.go
+++ b/src/phoenix/monitor/monitor.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"path"
 	"time"
@@ -317,7 +318,9 @@ func (nm *NodeMonitor) taskLauncher() {
 		}
 
 		fmt.Println("[Monitor: TaskLauncher] About to attempt launch task, active tasks: ", nm.activeTasks)
-		nm.logTimeStats()
+		if rand.Intn(20) == 0 {
+			nm.logTimeStats()
+		}
 		nm.attemptLaunchTask()
 
 		nm.launchCond.L.Unlock()


### PR DESCRIPTION
1. Used manual-2 to create ft-test which takes the following flags:
  a. conf string: config file
  b. n int: maximum number of workers to kill
  c. r bool: whether to recover killed workers
  d. w string: size of workload - big, medium, small
  e. seed: whether to use random task times in a job
  f. tasktime: mean task time in sec

Strategy: (for each workload size)
1. Measure overhead in scheduling starting from 0 to (#Monitors  - 1) failures to show that we give fault tolerance with some overhead.
2. Measure overhead with recovery set to True, show that we also achieve load balancing. Overhead for _n_ monitor crashes here should ideally be less than that for _n_ monitor crashes in the previous step.
3. Measure overhead for 0 failures with and w/o ZK.